### PR TITLE
fix(icons): fixes flash of large icons

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -11,9 +11,12 @@ import { useStaticQuery, graphql, Link } from 'gatsby';
 import styled, { createGlobalStyle, ThemeProvider } from 'styled-components';
 import breakpoint from 'styled-components-breakpoint';
 import { Normalize } from 'styled-normalize';
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
 import theme, { spacing } from '../styles';
-
 import Header from './Header';
+
+config.autoAddCss = false;
 
 const GlobalStyle = createGlobalStyle`
   body {


### PR DESCRIPTION
Fixes the flash of large icons on page load by forcing
the css styles inline

fixes #44
