### PR TITLE
feature/add tag component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,9 +33,7 @@ const config = {
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ['/node_modules/', '/styles/theme/'],
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",

--- a/src/components/atoms/Tag/Tag.jsx
+++ b/src/components/atoms/Tag/Tag.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types';
+import Link from 'next/link';
+import { rem, darken, lighten, readableColor } from 'polished';
+import { css, useTheme } from '@emotion/react';
+
+export function Tag({ label, slug, color }) {
+  const theme = useTheme();
+  const linkSlug = slug || label.toLowerCase().replace(/ /g, '-');
+
+  return (
+    <Link
+      css={css`
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: ${rem(20)};
+        padding: ${rem(8)};
+        color: ${color ? readableColor(color) : theme.colors.white};
+        font-size: ${rem(12)};
+        line-height: 1;
+        text-decoration: none;
+        background-color: ${color || theme.colors.gray};
+        border-radius: ${rem(12)};
+        transition: all 0.2s ease-in-out;
+
+        &:hover {
+          color: ${color ? readableColor(color) : theme.colors.white};
+          text-decoration: none;
+          background-color: ${lighten(0.1, color || theme.colors.gray)};
+        }
+
+        &:active {
+          background-color: ${darken(0.1, color || theme.colors.gray)};
+        }
+      `}
+      href={`/tags/${linkSlug}`}
+    >
+      {label}
+    </Link>
+  );
+}
+
+Tag.propTypes = {
+  label: PropTypes.string.isRequired,
+  slug: PropTypes.string,
+  color: PropTypes.string,
+};
+
+Tag.defaultProps = {
+  slug: '',
+  color: null,
+};
+
+export default Tag;

--- a/src/components/atoms/Tag/Tag.test.jsx
+++ b/src/components/atoms/Tag/Tag.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { parseToRgb } from 'polished';
+import { theme } from '@styles/theme';
+import { Tag } from './Tag';
+
+jest.mock('@emotion/react', () => ({
+  ...jest.requireActual('@emotion/react'),
+  useTheme: () => theme,
+}));
+
+describe('<Tag />', () => {
+  it('should render a tag', () => {
+    expect.assertions(5);
+
+    const { rerender } = render(<Tag label="Test Tag" slug="test" />);
+
+    expect(screen.getByText('Test Tag')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/tags/test');
+    expect(screen.getByRole('link')).toHaveStyle({
+      backgroundColor: parseToRgb('#666'),
+    });
+
+    rerender(<Tag label="Test Tag" color="#FFCC00" />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/tags/test-tag');
+
+    rerender(<Tag label="Test Tag" slug="test" color="#FFCC00" />);
+
+    expect(screen.getByRole('link')).toHaveStyle({
+      backgroundColor: parseToRgb('#FFCC00'),
+    });
+  });
+});

--- a/src/components/atoms/Tag/index.js
+++ b/src/components/atoms/Tag/index.js
@@ -1,0 +1,5 @@
+import { Tag } from './Tag';
+
+export * from './Tag';
+
+export default Tag;


### PR DESCRIPTION
- build: migrates to nextjs framework
- feat: adds emotion theme and css
- docs: adds storybook
- chore: moves pages under src folder
- feat: adds divider component
- build: adds legacy-peer-dep flag to npmrc
- feat(atoms): adds container component
- chore: sets version to lastest release version
- feat(molecules): adds section title components
- feat(atoms): adds tag component
- ci: removes style theme from test coverage
